### PR TITLE
Fix DoubleWatch reward logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,13 +92,11 @@
         (notifier
             .on('liveHeart', () => account.execute('liveheart'))
             .on('midnight', () => {
-                (async () => {
-                    await account.execute('livesign');
-                    await account.execute('idolclubsign');
-                    await account.execute('mainsharevideo');
-                    await account.execute('mainwatchvideo');
-                    await account.execute('doublewatch');
-                })();
+                account.execute('livesign');
+                account.execute('idolclubsign');
+                account.execute('mainsharevideo');
+                account.execute('mainwatchvideo');
+                account.execute('doublewatch');
                 account.execute('silverbox');
             }));
 
@@ -131,12 +129,12 @@
     function executeInitial(account) {
         account.refreshToken();
         (async () => {
-            await account.execute('livesign');
-            await account.execute('idolclubsign');
-            await account.execute('mainsharevideo');
-            await account.execute('mainwatchvideo');
-            await account.execute('doublewatch');
-            await account.execute('liveheart');
+            account.execute('livesign');
+            account.execute('idolclubsign');
+            account.execute('mainsharevideo');
+            account.execute('mainwatchvideo');
+            account.execute('doublewatch');
+            account.execute('liveheart');
             account.execute('silverbox');
         })();
     }


### PR DESCRIPTION
- Fix DoubleWatch reward logic so it will wait and retry if reward condition is not satisfied yet.
- Changed initial/midnight tasks to be running in parallel instead of sequential, as there does not seem to be a reason to do so.
- Minor change, return Promise from liveSilverBox() (even though it's not used).