### PR TITLE
Enhancement - Individually scheduled time for each day in a week

### DIFF
--- a/src/client/default-task-settings.json
+++ b/src/client/default-task-settings.json
@@ -27,7 +27,41 @@
                 "to": {
                     "hours": 0,
                     "minutes": 45
-                }
+                },
+                "weekdays": "1-4"
+            },
+            {
+                "from": {
+                    "hours": 8,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "5"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "6"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 0,
+                    "minutes": 45
+                },
+                "weekdays": "0"
             }
         ]
     },
@@ -43,7 +77,41 @@
                 "to": {
                     "hours": 0,
                     "minutes": 45
-                }
+                },
+                "weekdays": "1-4"
+            },
+            {
+                "from": {
+                    "hours": 8,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "5"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "6"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 0,
+                    "minutes": 45
+                },
+                "weekdays": "0"
             }
         ]
     },
@@ -59,7 +127,41 @@
                 "to": {
                     "hours": 0,
                     "minutes": 45
-                }
+                },
+                "weekdays": "1-4"
+            },
+            {
+                "from": {
+                    "hours": 8,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "5"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 2,
+                    "minutes": 0
+                },
+                "weekdays": "6"
+            },
+            {
+                "from": {
+                    "hours": 9,
+                    "minutes": 0
+                },
+                "to": {
+                    "hours": 0,
+                    "minutes": 45
+                },
+                "weekdays": "0"
             }
         ]
     },

--- a/src/client/tasks/scheduledtask.js
+++ b/src/client/tasks/scheduledtask.js
@@ -3,19 +3,16 @@
     'use strict';
 
     const DailyTask = require('./dailytask.js');
-    const TimePeriod = require('./timeperiod.js');
 
     class ScheduledTask extends DailyTask {
 
         constructor() {
             super();
-            this.timeperiod = [];
+            this.weeklySchedule = null;
         }
 
-        updateTimePeriod(...timeperiod) {
-            if (Array.isArray(timeperiod))
-                this.timeperiod = timeperiod.filter(t => (t && (t instanceof TimePeriod)));
-            return this;
+        updateTimePeriod(weeklySchedule) {
+            this.weeklySchedule = weeklySchedule;
         }
 
         execute(...args) {
@@ -26,15 +23,16 @@
 
         inBound() {
             let result = false;
-            if (this.timeperiod.length > 0)
-                result = this.timeperiod.some(timeperiod => timeperiod.inBound());
+            if (this.weeklySchedule) {
+                result = this.weeklySchedule.inBound();
+            }
             return result;
         }
 
         json() {
             let result = super.json();
-            result['type'] = 'scheduled';
-            result['timeperiod'] = this.timeperiod.map(tp => tp.json());
+            result.type = 'scheduled';
+            result.timeperiod = this.weeklySchedule.json();
             return result;
         }
     }

--- a/src/client/tasks/weeklyschedule.js
+++ b/src/client/tasks/weeklyschedule.js
@@ -1,0 +1,62 @@
+(function() {
+
+    'use strict';
+
+    const Clock = require('./clock.js');
+    const TimePeriod = require('./timeperiod.js');
+
+    class WeeklySchedule {
+
+        constructor(periods) {
+            const midnight = Clock.today();
+            this.originalPeriods = periods;
+            this.timePeriods = [ [], [], [], [], [], [], [] ];
+            periods.forEach(period => {
+                const fromTime = new Clock();
+                const toTime = new Clock();
+                fromTime.setHours(period.from.hours, period.from.minutes, 0, 0);
+                toTime.setHours(period.to.hours, period.to.minutes, 0, 0);
+
+                let currentDayTimePeriod = null;
+                let nextDayTimePeriod = null;
+                if (fromTime <= toTime) {
+                    currentDayTimePeriod = new TimePeriod(fromTime, toTime);
+                } else {
+                    currentDayTimePeriod = new TimePeriod(fromTime, midnight);
+                    nextDayTimePeriod = new TimePeriod(midnight, toTime);
+                }
+
+                (period.weekdays || '0-6').split(',').forEach(dayRange => {
+                    let current = 0;
+                    let end = 0;
+                    if (dayRange.includes('-')) {
+                        let days = dayRange.split('-');
+                        current = parseInt(days[0]);
+                        end = parseInt(days[1]);
+                    } else {
+                        current = parseInt(dayRange);
+                        end = current;
+                    }
+
+                    while (current <= end) {
+                        this.timePeriods[current++].push(currentDayTimePeriod);
+                        if (nextDayTimePeriod != null) {
+                            this.timePeriods[current == 7 ? 0 : current].push(nextDayTimePeriod);
+                        }
+                    }
+                });
+            });
+        }
+
+        inBound(time) {
+            return this.timePeriods[new Clock().getDay()].some(timeperiod => timeperiod.inBound());
+        }
+
+        json() {
+            return this.originalPeriods;
+        }
+    }
+
+    module.exports = WeeklySchedule;
+
+})();

--- a/src/main.js
+++ b/src/main.js
@@ -106,11 +106,7 @@
 
 
     function registerTasks(account) {
-        const from = Clock.today();
-        const to = Clock.today();
-        from.setHours(8, 0);
-        to.setHours(0, 45);
-        const tp = new TimePeriod(from, to);
+        const tp = [{from: { hours: 8, minutes: 0 }, to: { hours: 0, minutes: 45 }}];
 
         account.register('pk', { 'timeperiod': tp });
         account.register('gift', { 'timeperiod': tp });


### PR DESCRIPTION
Introduced a new "weekdays" property for each timeperiod. Valid values are 0-6, where 0 is Sunday, 1 is Monday, and so on (same as Date.getDay()). Multiple days can be used with comma as delimiter, and range can also be used with dash. For example, "1-3,5,6" means Monday to Wednesday, plus Friday and Saturday.

Default task settings are updated in this way:
- Weekday schedule starts at 8:00, and previous night ends at 0:45. This is the same as previous default.
- Weekend schedule starts at 9:00, and previous night ends at 2:00.