### PR TITLE
In rare cases the app crashes in receiver.js

### DIFF
--- a/src/client/receiver.js
+++ b/src/client/receiver.js
@@ -102,7 +102,7 @@
 
         onPing() {
             this.lastPing = +new Date();
-            this.ws.pong();
+            this.ws && this.ws.pong();
         }
 
         broadcast(gift) {


### PR DESCRIPTION
```
src\client\receiver.js:105
            this.ws.pong();
                    ^

TypeError: Cannot read property 'pong' of null
    at RaffleReceiver.onPing (src\client\receiver.js:105:21)
    at WebSocket.emit (events.js:223:5)
    at Receiver.receiverOnPing (node_modules\ws\lib\websocket.js:813:13)
    at Receiver.emit (events.js:223:5)
    at Receiver.controlMessage (node_modules\ws\lib\receiver.js:463:12)
    at Receiver.getData (node_modules\ws\lib\receiver.js:336:42)
    at Receiver.startLoop (node_modules\ws\lib\receiver.js:139:22)
    at Receiver._write (node_modules\ws\lib\receiver.js:74:10)
    at doWrite (_stream_writable.js:435:12)
    at writeOrBuffer (_stream_writable.js:419:5)
```

It might be that the socket got closed right after emitting a ping event and although JS code is running in single thread, VM still handles I/O asynchronously, i.e. it may be possible when websocket receiver is consuming data the socket is closed (pure speculation).

This fix just added a safety check in onPing().